### PR TITLE
Fix for #2, ESP32 crashes if NTP is configured without net

### DIFF
--- a/library.json
+++ b/library.json
@@ -24,7 +24,7 @@
         "authors": "Dominik Schösser, Leo Moll",
         "frameworks": "arduino"
     }],
-    "version": "0.1.6",
+    "version": "0.1.7",
     "frameworks": "arduino",
     "platforms": "espressif8266,espressif32"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=munet
-version=0.1.6
+version=0.1.7
 author=Dominik Schlösser, Leo Moll
 maintainer=Dominik Schlösser, <dsc@dosc.net>
 sentence=Modules for WLAN-Client, NTP, OTA, MQTT on ESP32/ESP8266 compatible with muwerk scheduler 


### PR DESCRIPTION
Prevent ESP32 from crashing because of configTime() being called before  WLAN is connected.
for Release 0.1.7