### PR TITLE
Hotfix/arduinonames

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ See [Example SerialBridge](https://github.com/muwerk/examples/tree/master/serial
 History
 -------
 
+- 0.4.0 (2021-01-30): **Breaking change** for ustd library include: ustd include-files have now `ustd_` prefix to prevent name-clashes with various platform-sdks. [queue.h clashed with ESP8266-Wifi, platform.h clashed with
+RISC-V SDK, hence new names `ustd_queue.h` and `ustd_platform.h` etc.]
 - 0.3.2 (2021-01-29): MuSerial: MQTT-enable non-networked hardware via serial link, NTP Bugfix, MQTT connection state fix.
   - Bugfix: NTP initialization on ESP8266 [failed often, #6](https://github.com/muwerk/munet/issues/6), due to unsafe parameter handling
    in current configTime() API of ESP8266, fixed.

--- a/library.json
+++ b/library.json
@@ -30,7 +30,7 @@
             "frameworks": "arduino"
         }
     ],
-    "version": "0.3.2",
+    "version": "0.4.0",
     "frameworks": "arduino",
     "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=munet
-version=0.3.2
+version=0.4.0
 author=Dominik Schlösser, Leo Moll
 maintainer=Dominik Schlösser, <dsc@dosc.net>
 sentence=Modules for Wifi connectivity, NTP, OTA, MQTT on ESP32/ESP8266 compatible with muwerk scheduler, serial link for other platforms

--- a/mqtt.h
+++ b/mqtt.h
@@ -9,9 +9,9 @@
 #include <Arduino_JSON.h>
 #include <PubSubClient.h>  // ESP32 requires v2.7 or later
 
-#include "platform.h"
-#include "array.h"
-#include "map.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
 
 #include "scheduler.h"
 #include "timeout.h"

--- a/muserial.h
+++ b/muserial.h
@@ -1,9 +1,9 @@
 // muserial.h
 #pragma once
 
-#include "platform.h"
-#include "array.h"
-#include "map.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
 
 #include "scheduler.h"
 //#include <Arduino_JSON.h>

--- a/net.h
+++ b/net.h
@@ -4,9 +4,9 @@
 
 // #if defined(__ESP__)
 
-#include "platform.h"
-#include "array.h"
-#include "map.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
 
 #include "scheduler.h"
 #include "sensors.h"

--- a/ota.h
+++ b/ota.h
@@ -5,9 +5,9 @@
 
 #include <functional>
 
-#include "platform.h"
-#include "array.h"
-#include "map.h"
+#include "ustd_platform.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
 
 #include "scheduler.h"
 #include "filesystem.h"

--- a/web.h
+++ b/web.h
@@ -3,7 +3,7 @@
 
 #if defined(__ESP__)
 
-#include "platform.h"
+#include "ustd_platform.h"
 
 #ifdef __ESP32__
 #include <WiFiClient.h>
@@ -15,8 +15,8 @@
 #include <ESP8266mDNS.h>
 #endif
 
-#include "array.h"
-#include "map.h"
+#include "ustd_array.h"
+#include "ustd_map.h"
 #include "scheduler.h"
 
 namespace ustd {


### PR DESCRIPTION
0.4.0 (2021-01-30): **Breaking change** for ustd library include: ustd include-files have now `ustd_` prefix to prevent name-clashes with various platform-sdks. [queue.h clashed with ESP8266-Wifi, platform.h clashed with
RISC-V SDK, hence new names `ustd_queue.h` and `ustd_platform.h` etc.]